### PR TITLE
Fix variance explained summary for dplyr 1.2.0

### DIFF
--- a/R/plot_variance_explained.R
+++ b/R/plot_variance_explained.R
@@ -153,8 +153,8 @@ plot_variance_explained = function(dataset, cols_metadata = NULL, rollup_algorit
     ## collect plot and summary stats (as plot/table)
     vp_sort = variancePartition::sortCols(variancePartition::sortCols(vp, FUN = mean), fun = stats::median)
     p_ve_violin = variancePartition::plotVarPart(vp_sort)
-    tbl_ve = as_tibble(as.matrix(vp_sort)) %>%
-      summarize_all(.funs = function(x) {bp=grDevices::boxplot.stats(x, do.conf=FALSE, do.out=FALSE)$stats; m=mean(x,na.rm=T); c(bp[5:4], m, bp[3:1])} ) %>% mutate_all(function(x) sprintf("%.1f", x * 100)) %>%
+    tbl_ve = tibble::as_tibble(lapply(tibble::as_tibble(as.matrix(vp_sort)), function(x) { bp = grDevices::boxplot.stats(x, do.conf = FALSE, do.out = FALSE)$stats; m = mean(x, na.rm = TRUE); c(bp[5:4], m, bp[3:1]) })) %>%
+      mutate(across(everything(), ~ sprintf("%.1f", .x * 100))) %>%
       add_column(statistic = c("boxplot upper whisker", "boxplot upper hinge", "mean", "median", "boxplot lower hinge", "boxplot lower whisker"), .before = 1)
 
     return(list(p_ve_violin=p_ve_violin, tbl_ve = tbl_ve, ve_data = vp_sort))


### PR DESCRIPTION
Fixes the variance explained summary table for dplyr 1.2.0.
`plot_variance_explained()` are using `summarize_all()` to return multiple summary rows per metadata column. With newer dplyr versions (>=1.2.0), multi-row `summarise()` output is no longer allowed, which caused `analysis_quickstart(var_explained_sample_metadata=...) ` to fail when generating the variance-explained section.
This change replaces that setp with a `tibble::as_tibble(lapply(...))` transformation while keeping the existing output unchanged.